### PR TITLE
Update the query selecting contact section heading

### DIFF
--- a/src/components/Footer/Footer.test.jsx
+++ b/src/components/Footer/Footer.test.jsx
@@ -21,7 +21,7 @@ describe('Footer', () => {
 
   it('renders contact section', () => {
     const heading = screen.getByRole('heading', {
-      name: /the accessory avenue/i,
+      name: /accessory avenue/i,
     });
     expect(heading).toBeInTheDocument();
 


### PR DESCRIPTION
The query is updated to select the heading
with the new and updated name (accessory avenue).