### PR TITLE
Make the menu start sticking at 50px from the top

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -8,7 +8,7 @@
   background: #000;
   margin-bottom: auto;
   position: sticky;
-  top: 55px;
+  top: 50px;
   z-index: 99;
 }
 


### PR DESCRIPTION
This change from 55px to 50px is needed after
the header's height (affected by the logo's height) has been reduced.